### PR TITLE
Fixed bad Dockerfile and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:7
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json /usr/src/app/
+RUN npm install
+
+# Bundle app source
+COPY . /usr/src/app
+
+CMD [ "node", "sensors-to-db.js" ]

--- a/README.md
+++ b/README.md
@@ -21,27 +21,49 @@ For this to work you need :
 To launch this app, you need to install all depencies (**npm install** in the directory) ant then you can run **npm start**
 
 But be sure to pass two variables to the script, like so :
-~~~bash
+```bash
 npm install
 npm start --broker=ws://localhost --db=mongo://localhost:27017/test
-~~~
+```
 _Note: if that doesn't work for you, try passing en extra -- before the first argument. It's because you dont have the last version of nodejs_
 
 Of, cours you should change the crendential to match yours.
 
 If you dont like this, you can still make it work be using environment variable, like so :
-~~~bash
+```bash
 SENSORS_TO_DB_BROKER=ws://localhost SENSORS_TO_DB_DB=mongo://localhost:27017/test npm start
-~~~
+```
 
 ## Docker
 
 The dockerfile let you easily launch the app.
 ~~~bash
-docker build -t sensorToDB .
-docker run -e "SENSORS_TO_DB_BROKER=ws://localhost" -e "SENSORS_TO_DB_DB=mongo://localhost:27017/test" sensorToDB
+docker build -t sensorstodb .
+docker run -e "SENSORS_TO_DB_BROKER=ws://localhost" -e "SENSORS_TO_DB_DB=mongo://localhost:27017/test" sensorstodb
 ~~~
 
-Of course you can change the environment variable, but they need to be set. The mongoDB instance and the Broker need to be up as well.
+Of course you can change the environment variables, but they need to be set. The mongoDB instance and the Broker need to be up as well.
 
-We recommend the use of a docker-compose.yml file.
+We recommend the use of a docker-compose.yml file. You can use the following `docker-compose.yml` :
+
+```yaml
+version: '2'
+services:
+  mosca:
+    image: matteocollina/mosca
+    ports:
+      - "8080:80"
+      - "1883:1883"
+
+  mongo:
+    image: mongo
+
+  sensorstodb:
+    build: .
+    environment:
+      - SENSORS_TO_DB_DB=mongo
+      - SENSORS_TO_DB_BROKER=mosca
+    depends_on:
+      - mosca
+      - mongo
+```

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ services:
   sensorstodb:
     build: .
     environment:
-      - SENSORS_TO_DB_DB=mongo
-      - SENSORS_TO_DB_BROKER=mosca
+      - SENSORS_TO_DB_DB=mongo://mongo:27017/test
+      - SENSORS_TO_DB_BROKER=ws://mosca
     depends_on:
       - mosca
       - mongo

--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,0 @@
-FROM node:6.9
-MAINTAINER MERLIN
-
-RUN useradd -m sensorsToDB -d /home/sensorsToDB
-
-VOLUME /home/sensorsToDB
-WORKDIR /home/sensorsToDB
-
-CMD ["sh","-c","npm install --reinstall; npm start"]


### PR DESCRIPTION
Because I use submodules for my MQTT API, I fixed the Merlin's defective Dockerfile, and stuffed a little the README. The sensors-to-db is now submodule-ready, with a docker-compose for example.