### PR TITLE
Added an entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:7
 
+RUN apt-get update && apt-get -qq install netcat
+
 # Create app directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -12,6 +14,7 @@ RUN npm install
 COPY . /usr/src/app
 
 RUN chmod +x ./node_modules/.bin/babel
+RUN chmod 0755 entrypoint.sh
 
 RUN npm run compile
 

--- a/README.md
+++ b/README.md
@@ -55,15 +55,30 @@ services:
       - "8080:80"
       - "1883:1883"
 
-  mongo:
+  mongodb:
     image: mongo
 
   sensorstodb:
     build: .
     environment:
-      - SENSORS_TO_DB_DB=mongodb://mongo:27017/test
+      - SENSORS_TO_DB_DB=mongodb://mongodb:27017/test
       - SENSORS_TO_DB_BROKER=ws://mosca
     depends_on:
       - mosca
       - mongo
+```
+
+The connection to mongodb is blocking : if the mongodb server isn't ready, but the script tries to access to it, an exception will be raised, and the script will stop. To avoid this, we'll set an entrypoint which will wait for the mongo server to be reachable before launching the sensors-to-db app.
+
+```yaml
+sensors-to-db:
+  build: docker/sensorstodb
+  entrypoint: /usr/src/app/entrypoint.sh
+  command: [ node, dist/sensors-to-db.js ]
+  environment:
+    - SENSORS_TO_DB_DB=mongodb://mongodb:27017/test
+    - SENSORS_TO_DB_BROKER=ws://mosca
+  depends_on:
+    - mongodb
+    - mosca
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ $# -gt 0 ] && [ "$1" = "node" ]; then
+    while ! nc -z mongodb 27017; do
+	echo "Waiting for MongoDB..."
+	sleep 3;
+    done
+fi
+
+exec "$@"


### PR DESCRIPTION
The connection to mongodb can fail and force the script to stop because the mongo server isn't ready yet. This docker-compose entrypoint will wait for the mongo server to be available before launching the script